### PR TITLE
Amélioration du code des thèmes

### DIFF
--- a/css/mediaboxBlack.css
+++ b/css/mediaboxBlack.css
@@ -38,10 +38,6 @@
 	-khtml-box-shadow: 0px 5px 20px rgba(0,0,0,0.50);
 	-moz-box-shadow: 0px 5px 20px rgba(0,0,0,0.50);
 	box-shadow: 0px 5px 20px rgba(0,0,0,0.50);
-	/* For IE 8 */
-	-ms-filter: "progid:DXImageTransform.Microsoft.Shadow(Strength=5, Direction=180, Color='#000000')";
-	/* For IE 5.5 - 7 */
-	filter: progid:DXImageTransform.Microsoft.Shadow(Strength=5, Direction=180, Color='#000000');
 }
 #mbCenter img{
 	border-radius: 4px;

--- a/css/mediaboxWhite.css
+++ b/css/mediaboxWhite.css
@@ -38,11 +38,8 @@
 	-khtml-box-shadow: 0px 5px 20px rgba(0,0,0,0.50);
 	-moz-box-shadow: 0px 5px 20px rgba(0,0,0,0.50);
 	box-shadow: 0px 5px 20px rgba(0,0,0,0.50);
-	/* For IE 8 */
-	-ms-filter: "progid:DXImageTransform.Microsoft.Shadow(Strength=5, Direction=180, Color='#000000')";
-	/* For IE 5.5 - 7 */
-	filter: progid:DXImageTransform.Microsoft.Shadow(Strength=5, Direction=180, Color='#000000');
 }
+
 #mbCenter img{
 	border-radius: 4px;
 }

--- a/index.php
+++ b/index.php
@@ -37,7 +37,7 @@ by Sébastien SAUVAGE.
 	$starttime = $mtime;
 */
 
-header('Content-Type: text/html; charset=utf-8'); // We use UTF-8 for proper international characters handling.
+header('Content-Type: text/html; charset=UTF-8'); // We use UTF-8 for proper international characters handling.
 $version = "0.3.7";
 ini_set("memory_limit","256M");
 
@@ -236,13 +236,13 @@ if (file_exists($currentdir ."/captions.txt"))
 			  				"name" => $file,
 							"date" => filemtime($currentdir . "/" . $file),
 							"size" => filesize($currentdir . "/" . $file),
-				  			"html" => "<li><a href='" . $currentdir . "/" . $file . "' rel='lightbox[billeder]' title=\"".htmlentities($img_captions[$file])."\"><img class=\"b-lazy\" src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw== data-src='" . GALLERY_ROOT . "createthumb.php?filename=" . $thumbdir . "/" . $file . "&amp;size=$thumb_size' alt='$label_loading' /></a></li>");
+				  			"html" => "<li><a href='" . $currentdir . "/" . $file . "' title=\"".htmlentities($img_captions[$file])."\"><img class=\"b-lazy\" src=\"data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==\" data-src='" . GALLERY_ROOT . "createthumb.php?filename=" . $thumbdir . "/" . $file . "&amp;size=$thumb_size' alt='$label_loading' /></a></li>");
 						} else {
 							$files[] = array (
 			  				"name" => $file,
 							"date" => filemtime($currentdir . "/" . $file),
 							"size" => filesize($currentdir . "/" . $file),
-				  			"html" => "<li><a href='" . $currentdir . "/" . $file . "' rel='lightbox[billeder]' title=\"".htmlentities($img_captions[$file])."\"><img  src='" . GALLERY_ROOT . "createthumb.php?filename=" . $thumbdir . "/" . $file . "&amp;size=$thumb_size' alt='$label_loading' /></a></li>");
+				  			"html" => "<li><a href='" . $currentdir . "/" . $file . "' title=\"".htmlentities($img_captions[$file])."\"><img  src='" . GALLERY_ROOT . "createthumb.php?filename=" . $thumbdir . "/" . $file . "&amp;size=$thumb_size' alt='$label_loading' /></a></li>");
 						}
 		  			}
 					// Other filetypes
@@ -356,7 +356,7 @@ if ($requestedDir != "")
 //Include hidden links for all images BEFORE current page so lightbox is able to browse images on different pages
 for ($y = 0; $y < $offset_start - sizeof($dirs); $y++)
 {	
-	$breadcrumb_navigation .= "<a href='" . $currentdir . "/" . $files[$y]["name"] . "' rel='lightbox[billeder]' class='hidden' title='" . $img_captions[$files[$y]["name"]] . "'></a>";
+	$breadcrumb_navigation .= "<a href='" . $currentdir . "/" . $files[$y]["name"] . "' class='hidden' title='" . $img_captions[$files[$y]["name"]] . "'></a>";
 }
 
 //-----------------------
@@ -389,7 +389,7 @@ for ($i = $offset_start - sizeof($dirs); $i < $offset_end && $offset_current < $
 if ($i<0) $i=1;
 for ($y = $i; $y < sizeof($files); $y++)
 {	
-	$page_navigation .= "<a href='" . $currentdir . "/" . $files[$y]["name"] . "' rel='lightbox[billeder]'  class='hidden' title='" . $img_captions[$files[$y]["name"]] . "'></a>";
+	$page_navigation .= "<a href='" . $currentdir . "/" . $files[$y]["name"] . "'  class='hidden' title='" . $img_captions[$files[$y]["name"]] . "'></a>";
 }
 
 //-----------------------

--- a/templates/board.html
+++ b/templates/board.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
 	<head>
 		<meta charset="UTF-8">
@@ -6,12 +6,7 @@
 		<meta name="generator" content="MinigalNano <% version %>" />
 		<title><% title %></title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<link rel="alternate" type="application/rss+xml" title="<% title %>" href="rss/" /><link>
-		
-		<script src="<% gallery_root %>js/lazy.js"></script>
-		<script src="<% gallery_root %>js/script.js"></script>
-		<script src="<% gallery_root %>js/mootools.js"></script>
-		<script src="<% gallery_root %>js/mediabox1.3.4.js"></script>
+		<link rel="alternate" type="application/rss+xml" title="<% title %>" href="rss/" />
 
 		<link rel="stylesheet" href="<% gallery_root %>css/mediaboxWhite.css" type="text/css" media="screen" />
 		<style type="text/css">
@@ -75,7 +70,6 @@
 			#backtop:active,
 			.b-lazy {
 				-webkit-transition:all .2s ease-in;
-				-ms-transition:all .2s ease-in;
 				-o-transition:all .2s ease-in;
 				transition:all .2s ease-in;
 			}
@@ -167,24 +161,26 @@
 				}
 			}
 		</style>
+		
+		<script src="<% gallery_root %>js/lazy.js"></script>
+		<script src="<% gallery_root %>js/script.js"></script>
+		<script src="<% gallery_root %>js/mootools.js"></script>
+		<script src="<% gallery_root %>js/mediabox1.3.4.js"></script>
 	</head>
-
 	<body>
-		<header  role="banner">
+		<header id="top" role="banner">
 			<div id="innerheader">
 				<h1><a href="<% gallery_root %>"><% title %></a></h1>
 				<% messages %>
 				<nav role="navigation"><% breadcrumb_navigation %></nav>
 				<aside><% folder_comment %></aside>
 			</div>
-		</header>
-		
+		</header>	
 		<main id="container">
 			<ul id="gallery">
 				<% thumbnails %>
 			</ul>
 		</main>
-
 		<nav class="clear" role="navigation"><% page_navigation %></nav>
 		<a href="#top" id="backtop">top</a>
 		<footer role="contentinfo">
@@ -195,9 +191,9 @@
 			<a href="http://tomcanac.com/minigal/" title="Tom Canac" target="_blank">
 				Board theme by Tom Canac
 			</a> /
-			<a  title="<% title %> RSS" href="rss/" />
+			<a  title="<% title %> RSS" href="rss/">
 				RSS
-			<a>
+			</a>
 		</footer>
 	</body>
 </html>

--- a/templates/darkgold3.html
+++ b/templates/darkgold3.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
 	<head>
 		<meta charset="UTF-8">
@@ -6,214 +6,209 @@
 		<meta name="generator" content="MinigalNano <% version %>" />
 		<title><% title %></title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<link rel="alternate" type="application/rss+xml" title="<% title %>" href="rss/" /><link>
+		<link rel="alternate" type="application/rss+xml" title="<% title %>" href="rss/" />
 		
+		<link rel="stylesheet" href="<% gallery_root %>css/mediaboxWhite.css" type="text/css" media="screen" />
+		<style type="text/css">
+			body {
+				margin: 0 auto;
+				padding: 0;
+				width: <% gallery_width %>;
+				font: 12px Tahoma,Verdana,Arial,Helvetica, sans-serif;
+				background: #272727;
+				color: #BDBDBD;
+			}
+			h1 {
+				font: normal 250%/100% "Trebuchet MS",Tahoma,Verdana,Arial,Helvetica, sans-serif;
+				margin: 20px 0 5px 0;
+				letter-spacing: -1px;
+				color: #FFCC11;	
+				text-shadow: #000000 2px 2px 2px;
+			}
+			.credits {
+				border-bottom: solid 1px #434343;
+				padding-bottom: 5px;
+				margin-bottom: 5px;
+				color: #CF8D26;
+				font: 100% "Trebuchet MS",Tahoma,Verdana,Arial,Helvetica, sans-serif;
+			}
+			.credits em {
+				color: #BDBDBD;
+				font-style: normal;
+				font-style: normal;
+			}
+			footer {
+				text-align: center;
+			}
+			footer a {
+				font-size: 10px;
+				text-decoration: none;
+				color: #666;
+			}
+			footer a:hover,
+			footer a:visited:hover {
+				color: #888;
+			}
+			img {
+				border: none;
+			}
+			#page_nav {
+				color: #BDBDBD;
+				clear:both;
+				text-align: center;
+			}
+			#page_nav a:link, #page_nav a:visited, #page_nav a:hover, #page_nav a:visited:hover {
+				text-decoration: none;
+				color: #FFCC11;
+			}
+			#breadcrumb_nav {
+				color: #BDBDBD;
+				font-weight: bold;
+			}
+			#breadcrumb_nav a:link, #breadcrumb_nav a:visited, #breadcrumb_nav a:hover, #breadcrumb_nav a:visited:hover {
+				text-decoration: none;
+				color: #FFCC11;
+			}
+			a {
+				color: #FFCC11;
+			}
+			#container {
+				overflow: auto;
+				width: 100%
+			}
+			.hidden {
+				visibility: hidden;
+				position:absolute;
+				top: 0;
+				left: 0;
+				display:inline;
+			}
+			#topbar {
+				border-bottom-color: #afafaf;
+				border-style: none;
+				color: black;
+				position: absolute;
+				left: 0;
+				top: 0;
+				margin: 0;
+				padding-top: 5px;
+				float: none;
+				width: 100%;
+				height: 25px;
+				text-align: center;
+				background-color: #FFFF99;
+				border-bottom: 1px solid;
+			}
+			#topbar a:link, #topbar a:visited, #topbar a:hover, #topbar a:visited:hover {
+				text-decoration: underline;
+				color: #000;
+			}
+			#topbar img{
+				position: absolute;
+				right: 6%;
+				top: 6%;
+				vertical-align: middle;
+			}
+
+			#folder_comment
+			{
+				margin-bottom:10px;
+			}
+
+			#folder_comment a {
+			color: #FFCC11;
+			text-decoration: none;
+
+			}
+			/* ---------- gallery styles start here ----------------------- */
+			.gallery {
+				list-style: none;
+				margin: 0;
+				padding: 0;
+			}
+			.gallery li {
+			
+				margin: 1px;
+				float: left;
+				position: relative;
+				width: 33%;
+				height: 240px;
+				overflow:hidden;
+			}
+			.gallery li:hover img {
+				background: #ddd;
+				opacity: 0.7;
+			}
+			.gallery img {
+				background: #000;
+				color: #666;
+			}
+			.gallery em {
+				background: #000;
+				color: #FFCC11;
+				font-family: "Trebuchet MS",Tahoma,Verdana,Arial,Helvetica, sans-serif;
+				font-style: normal;
+				font-weight: bold;
+				font-size: 14px;
+				padding: 8px 2px;
+				display: block;
+				position: absolute;
+				/* top: 90px; */
+				bottom:20px;
+				left: 0px;
+				width: 320px;
+				/* height: 40px; */
+				opacity: 0.6;
+			}
+			.gallery em-pdf {
+				color: #666;
+				font-style: normal;
+				font-size: 10px;
+				padding: 3px 7px;
+				display: block;
+				position: absolute;
+				top: 100px;
+				left: 0px;
+			}
+			.gallery a {
+				text-decoration: none;
+			}
+			.gallery a:hover em {
+				background: grey;
+				color: black;
+			}
+		</style>
+
 		<script src="<% gallery_root %>js/lazy.js"></script>
 		<script src="<% gallery_root %>js/script.js"></script>
 		<script src="<% gallery_root %>js/mootools.js"></script>
 		<script src="<% gallery_root %>js/mediabox1.3.4.js"></script>
 
-		<link rel="stylesheet" href="<% gallery_root %>css/mediaboxWhite.css" type="text/css" media="screen" />
-		<style type="text/css">
-		body {
-			margin: 0 auto;
-			padding: 0;
-			width: <% gallery_width %>;
-			font: 12px Tahoma,Verdana,Arial,Helvetica, sans-serif;
-			background: #272727;
-			color: #BDBDBD;
-		}
-		h1 {
-			font: normal 250%/100% "Trebuchet MS",Tahoma,Verdana,Arial,Helvetica, sans-serif;
-			margin: 20px 0 5px 0;
-			letter-spacing: -1px;
-			color: #FFCC11;	
-			text-shadow: #000000 2px 2px 2px;
-		}
-		.credits {
-			border-bottom: solid 1px #434343;
-			padding-bottom: 5px;
-			margin-bottom: 5px;
-			color: #CF8D26;
-			font: 100% "Trebuchet MS",Tahoma,Verdana,Arial,Helvetica, sans-serif;
-		}
-		.credits em {
-			color: #BDBDBD;
-			font-style: normal;
-			font-style: normal;
-		}
-		footer {
-			text-align: center;
-		}
-		footer a {
-			font-size: 10px;
-			text-decoration: none;
-			color: #666;
-		}
-		footer a:hover,
-		footer a:visited:hover {
-			color: #888;
-		}
-		img {
-			border: none;
-		}
-		#page_nav {
-			color: #BDBDBD;
-			clear:both;
-			text-align: center;
-		}
-		#page_nav a:link, #page_nav a:visited, #page_nav a:hover, #page_nav a:visited:hover {
-			text-decoration: none;
-			color: #FFCC11;
-		}
-		#breadcrumb_nav {
-			color: #BDBDBD;
-			font-weight: bold;
-		}
-		#breadcrumb_nav a:link, #breadcrumb_nav a:visited, #breadcrumb_nav a:hover, #breadcrumb_nav a:visited:hover {
-			text-decoration: none;
-			color: #FFCC11;
-		}
-		a {
-			color: #FFCC11;
-		}
-		#container {
-			overflow: auto;
-			width: 100%
-		}
-		.hidden {
-			visibility: hidden;
-			position:absolute;
-			top:0;
-			left:0;
-			display:inline;
-		}
-		#topbar {
-			border-bottom-color: #afafaf;
-			border-style: none;
-			color: black;
-			position: absolute;
-			left: 0;
-			top: 0;
-			margin: 0;
-			padding-top: 5px;
-			float: none;
-			width: 100%;
-			height: 25px;
-			text-align: center;
-			background-color: #FFFF99;
-			border-bottom: 1px solid;
-		}
-		#topbar a:link, #topbar a:visited, #topbar a:hover, #topbar a:visited:hover {
-			text-decoration: underline;
-			color: #000;
-		}
-		#topbar img{
-			position: absolute;
-			right: 6;
-			top: 6;
-			vertical-align: middle;
-		}
-
-		#folder_comment
-		{
-			margin-bottom:10px;
-		}
-
-		#folder_comment a {
-		color: #FFCC11;
-		text-decoration: none;
-
-		}
-		/* ---------- gallery styles start here ----------------------- */
-		.gallery {
-			list-style: none;
-			margin: 0;
-			padding: 0;
-		}
-		.gallery li {
-			
-			margin: 1px;
-			float: left;
-			position: relative;
-			width: 33%;
-			height: 240px;
-			overflow:hidden;
-		}
-		.gallery li:hover img {
-			background: #ddd;
-			filter: alpha(opacity=70);
-			filter: progid:DXImageTransform.Microsoft.Alpha(opacity=70);
-			-moz-opacity: 0.70;
-			opacity:0.7;
-		}
-		.gallery img {
-			background: #000;
-			color: #666;
-		}
-		.gallery em {
-			background: #000;
-			color: #FFCC11;
-			font-family: "Trebuchet MS",Tahoma,Verdana,Arial,Helvetica, sans-serif;
-			font-style: normal;
-			font-weight: bold;
-			font-size: 14px;
-			padding: 8px 2px;
-			display: block;
-			position: absolute;
-			/* top: 90px; */
-			bottom:20px;
-			left: 0px;
-			width: 320px;
-			/* height: 40px; */
-			filter: alpha(opacity=60);
-			filter: progid:DXImageTransform.Microsoft.Alpha(opacity=60);
-			-moz-opacity: 0.60;
-			opacity:0.6;
-		}
-		.gallery em-pdf {
-			color: #666;
-			font-style: normal;
-			font-size: 10px;
-			padding: 3px 7px;
-			display: block;
-			position: absolute;
-			top: 100px;
-			left: 0px;
-		}
-		.gallery a {
-			text-decoration: none;
-		}
-		.gallery a:hover em {
-			background: grey;
-			color: black;
-		}
-	</style>
-</head>
-<body>
-	<header role="banner">
-		<h1><% title %></h1>
-		<% messages %>
-		<p class="credits"><em>by: </em><% author %></p>
-		<nav id="breadcrumb_nav" role="navigation"><% breadcrumb_navigation %></nav>
-	</header>
-	<section id="container">
-		<p id="folder_comment"><% folder_comment %></p>
-		<ul class="gallery">
-			<% thumbnails %>
-		</ul>
-	</section>
-	<br />
-	<nav id="page_nav" role="navigation"><% page_navigation %></nav>
-	<br />
-	<footer role="contentinfo">
-		Gallery by <% author %>.
-		<a href="https://github.com/sebsauvage/MinigalNano" title="Powered by MiniGal Nano" target="_blank">
-			Powered by MiniGal Nano <% version %>
-		</a> |
-		<a  title="<% title %> RSS" href="rss/" />
-			RSS
-		<a>
-	</footer>
-</body>
+	</head>
+	<body>
+		<header role="banner">
+			<h1><% title %></h1>
+			<% messages %>
+			<p class="credits"><em>by: </em><% author %></p>
+			<nav id="breadcrumb_nav" role="navigation"><% breadcrumb_navigation %></nav>
+		</header>
+		<section id="container">
+			<p id="folder_comment"><% folder_comment %></p>
+			<ul class="gallery">
+				<% thumbnails %>
+			</ul>
+		</section>
+		<br />
+		<nav id="page_nav" role="navigation"><% page_navigation %></nav>
+		<br />
+		<footer role="contentinfo">
+			Gallery by <% author %> |
+			<a href="https://github.com/sebsauvage/MinigalNano" title="Powered by MiniGal Nano" target="_blank">
+				Powered by MiniGal Nano <% version %>
+			</a> |
+			<a  title="<% title %> RSS" href="rss/">
+				RSS
+			</a>
+		</footer>
+	</body>
 </html>

--- a/templates/darksideboard.html
+++ b/templates/darksideboard.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
 	<head>
 		<meta charset="UTF-8">
@@ -6,12 +6,7 @@
 		<meta name="generator" content="MinigalNano <% version %>" />
 		<title><% title %></title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<link rel="alternate" type="application/rss+xml" title="<% title %>" href="rss/" /><link>
-		
-		<script src="<% gallery_root %>js/lazy.js"></script>
-		<script src="<% gallery_root %>js/script.js"></script>
-		<script src="<% gallery_root %>js/mootools.js"></script>
-		<script src="<% gallery_root %>js/mediabox1.3.4.js"></script>
+		<link rel="alternate" type="application/rss+xml" title="<% title %>" href="rss/" />
 
 		<link rel="stylesheet" href="<% gallery_root %>css/mediaboxWhite.css" type="text/css" media="screen" />
 		<style type="text/css">
@@ -79,7 +74,6 @@
 			#backtop:active,
 			.b-lazy {
 				-webkit-transition:all .2s ease-in;
-				-ms-transition:all .2s ease-in;
 				-o-transition:all .2s ease-in;
 				transition:all .2s ease-in;
 			}
@@ -169,10 +163,14 @@
 				}
 			}
 		</style>
+		
+		<script src="<% gallery_root %>js/lazy.js"></script>
+		<script src="<% gallery_root %>js/script.js"></script>
+		<script src="<% gallery_root %>js/mootools.js"></script>
+		<script src="<% gallery_root %>js/mediabox1.3.4.js"></script>
 	</head>
-
 	<body>
-		<header  role="banner">
+		<header id="top" role="banner">
 			<div id="innerheader">
 				<h1><a href="<% gallery_root %>"><% title %></a></h1>
 				<% messages %>
@@ -180,13 +178,11 @@
 				<aside><% folder_comment %></aside>
 			</div>
 		</header>
-		
 		<main id="container">
 			<ul id="gallery">
 				<% thumbnails %>
 			</ul>
 		</main>
-
 		<nav class="clear" role="navigation"><% page_navigation %></nav>
 		<a href="#top" id="backtop">top</a>
 		<footer role="contentinfo">
@@ -197,9 +193,9 @@
 			<a href="http://tomcanac.com/minigal/" title="Tom Canac" target="_blank">
 				Board theme by Tom Canac
 			</a> /
-			<a  title="<% title %> RSS" href="rss/" />
+			<a  title="<% title %> RSS" href="rss/">
 				RSS
-			<a>
+			</a>
 		</footer>
 	</body>
 </html>

--- a/templates/rounded.html
+++ b/templates/rounded.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
 	<head>
 		<meta charset="UTF-8">
@@ -6,12 +6,7 @@
 		<meta name="generator" content="MinigalNano <% version %>" />
 		<title><% title %></title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<link rel="alternate" type="application/rss+xml" title="<% title %>" href="rss/" /><link>
-		
-		<script src="<% gallery_root %>js/lazy.js"></script>
-		<script src="<% gallery_root %>js/script.js"></script>
-		<script src="<% gallery_root %>js/mootools.js"></script>
-		<script src="<% gallery_root %>js/mediabox1.3.4.js"></script>
+		<link rel="alternate" type="application/rss+xml" title="<% title %>" href="rss/" />
 
 		<link rel="stylesheet" href="<% gallery_root %>css/mediaboxWhite.css" type="text/css" media="screen" />
 		<style type="text/css">
@@ -103,7 +98,6 @@
 			#backtop:active,
 			.b-lazy {
 				-webkit-transition:all .2s ease-in;
-				-ms-transition:all .2s ease-in;
 				-o-transition:all .2s ease-in;
 				transition:all .2s ease-in;
 			}
@@ -111,7 +105,6 @@
 				position:absolute;
 				top:-1px;
 				bottom:-1px;
-				zoom:1;
 				width:100%;
 				margin:-0.5px 0 0 -0.5px;
 				padding:40% 0;
@@ -124,12 +117,9 @@
 				color:#FFF;
 				opacity:0;
 				background:#000;
-				filter:alpha(opacity=0);
 			}
 			#gallery li:hover em {
-				zoom:1;
 				opacity:1;
-				filter:alpha(opacity=1);
 			}
 			footer {
 				clear:both;
@@ -189,17 +179,20 @@
 				}
 			}
 		</style>
+		
+		<script src="<% gallery_root %>js/lazy.js"></script>
+		<script src="<% gallery_root %>js/script.js"></script>
+		<script src="<% gallery_root %>js/mootools.js"></script>
+		<script src="<% gallery_root %>js/mediabox1.3.4.js"></script>
 	</head>
-
 	<body>
-		<header  role="banner">
+		<header id="top" role="banner">
 			<div id="innerheader">
 				<h1><a href="<% gallery_root %>"><% title %></a></h1>
 				<% messages %>
 				<nav role="navigation"><% breadcrumb_navigation %></nav>
 			</div>
 		</header>
-		<a href="#top" id="backtop">top</a>
 		<main id="container">
 			<header><% folder_comment %></header>
 			<ul id="gallery">
@@ -216,9 +209,9 @@
 			<a href="http://tomcanac.com/minigal/" title="Tom Canac" target="_blank">
 				Rounded theme by Tom Canac
 			</a> /
-			<a  title="<% title %> RSS" href="rss/" />
+			<a  title="<% title %> RSS" href="rss/">
 				RSS
-			<a>
+			</a>
 		</footer>
 	</body>
 </html>

--- a/templates/squares.html
+++ b/templates/squares.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
 	<head>
 		<meta charset="UTF-8">
@@ -6,12 +6,7 @@
 		<meta name="generator" content="MinigalNano <% version %>" />
 		<title><% title %></title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<link rel="alternate" type="application/rss+xml" title="<% title %>" href="rss/" /><link>
-		
-		<script src="<% gallery_root %>js/lazy.js"></script>
-		<script src="<% gallery_root %>js/script.js"></script>
-		<script src="<% gallery_root %>js/mootools.js"></script>
-		<script src="<% gallery_root %>js/mediabox1.3.4.js"></script>
+		<link rel="alternate" type="application/rss+xml" title="<% title %>" href="rss/" />
 
 		<link rel="stylesheet" href="<% gallery_root %>css/mediaboxWhite.css" type="text/css" media="screen" />
 		<style type="text/css">
@@ -70,7 +65,6 @@
 			#backtop:active,
 			.b-lazy {
 				-webkit-transition:all .2s ease-in;
-				-ms-transition:all .2s ease-in;
 				-o-transition:all .2s ease-in;
 				transition:all .2s ease-in;
 			}
@@ -163,8 +157,12 @@
 				}
 			}
 		</style>
+		
+		<script src="<% gallery_root %>js/lazy.js"></script>
+		<script src="<% gallery_root %>js/script.js"></script>
+		<script src="<% gallery_root %>js/mootools.js"></script>
+		<script src="<% gallery_root %>js/mediabox1.3.4.js"></script>
 	</head>
-
 	<body>
 		<header id="top" role="banner">
 			<div id="innerheader">
@@ -173,14 +171,12 @@
 				<nav role="navigation"><% breadcrumb_navigation %></nav>
 			</div>
 		</header>
-		
 		<main id="container">
 			<header><% folder_comment %></header>
 			<ul id="gallery">
 				<% thumbnails %>
 			</ul>
 		</main>
-
 		<nav role="navigation"><% page_navigation %></nav>
 		<a href="#top" id="backtop">top</a>
 		<footer role="contentinfo">
@@ -191,9 +187,9 @@
 			<a href="http://tomcanac.com/minigal/" title="Tom Canac" target="_blank">
 				Squares theme by Tom Canac
 			</a> /
-			<a  title="<% title %> RSS" href="rss/" />
+			<a  title="<% title %> RSS" href="rss/">
 				RSS
-			<a>
+			</a>
 		</footer>
 	</body>
 </html>


### PR DESCRIPTION
Diverses amélioration du code des thèmes afin que les pages générées soient en HTML5 et CSS3 valides. Cela impliquant le retrait de la [propriété non-standard filter](https://developer.mozilla.org/en-US/docs/Web/CSS/filter#Internet_Explorer_notes) présente dans Internet Explorer 4 à 9, accepter ce patch revient à abandonner le support d'Internet Explorer pour les versions antérieures à la 9.
