### PR TITLE
Correction couleur liens

### DIFF
--- a/templates/darksideboard.html
+++ b/templates/darksideboard.html
@@ -90,7 +90,10 @@
 			}
 			#gallery li img{
 				width: 100%;
-			}	
+			}
+			#gallery a {
+				color: #222;
+			}
 			#gallery em {
 				background: #FFF;
 				text-align: center;


### PR DESCRIPTION
Sur la page d'accueil du template darksideboard, les liens sous les "entrées de galeries" sont en gris très clair sur fond blanc, du coup le titre des galeries n'est pas lisible.

J'ai ajouté une règles pour ces liens. Je ne sais pas si c'est la meilleure méthode.
