### PR TITLE
Slashes unescaping seemed overcomplicated.

### DIFF
--- a/index.php
+++ b/index.php
@@ -289,7 +289,7 @@ $dirs = array();
 						if (is_file($currentdir.'/'.$file.'.html')) {
 							$img_captions[$file] = $file.'::'.htmlspecialchars(file_get_contents($currentdir.'/'.$file.'.html'),ENT_QUOTES);
 						}
-						$linkUrl = join("/", array_merge(array_map(rawurlencode, split("/", $currentdir)), array(rawurlencode($file))));
+						$linkUrl = str_replace('%2F', '/', rawurlencode("$currentdir/$file"));
 						$imgParams = http_build_query(
 							array(
 								'filename' => "$thumbdir/$file",


### PR DESCRIPTION
I think we're seeing the end of it.

Apache don't really like escaped slashes in the <path> part of the URI. They have a config option to support it though, but it's [disabled by default](https://httpd.apache.org/docs/2.2/mod/core.html#allowencodedslashes).

This commit simplifies the fix #64 :smile: 
