### PR TITLE
Fixing unescaped . in the file extension detection regex

### DIFF
--- a/index.php
+++ b/index.php
@@ -312,16 +312,16 @@ if (is_dir($currentdir) && $handle = opendir($currentdir)) {
             }
             // Other filetypes
             $extension = "";
-            if (preg_match("/.pdf$/i", $file)) $extension = "PDF"; // PDF
-            if (preg_match("/.zip$/i", $file)) $extension = "ZIP"; // ZIP archive
-            if (preg_match("/.rar$|.r[0-9]{2,}/i", $file)) $extension = "RAR"; // RAR Archive
-            if (preg_match("/.tar$/i", $file)) $extension = "TAR"; // TARball archive
-            if (preg_match("/.gz$/i", $file)) $extension = "GZ"; // GZip archive
-            if (preg_match("/.doc$|.docx$/i", $file)) $extension = "DOCX"; // Word
-            if (preg_match("/.ppt$|.pptx$/i", $file)) $extension = "PPTX"; //Powerpoint
-            if (preg_match("/.xls$|.xlsx$/i", $file)) $extension = "XLXS"; // Excel
-            if (preg_match("/.ogv$|.mp4$|.mpg$|.mpeg$|.mov$|.avi$|.wmv$|.flv$|.webm$/i", $file)) $extension = "VIDEO"; // video files
-            if (preg_match("/.aiff$|.aif$|.wma$|.aac$|.flac$|.mp3$|.ogg$|.m4a$/i", $file)) $extension = "AUDIO"; // audio files
+            if (preg_match("/\.pdf$/i", $file)) $extension = "PDF"; // PDF
+            if (preg_match("/\.zip$/i", $file)) $extension = "ZIP"; // ZIP archive
+            if (preg_match("/\.rar$|\.r[0-9]{2,}/i", $file)) $extension = "RAR"; // RAR Archive
+            if (preg_match("/\.tar$/i", $file)) $extension = "TAR"; // TARball archive
+            if (preg_match("/\.gz$/i", $file)) $extension = "GZ"; // GZip archive
+            if (preg_match("/\.doc$|\.docx$/i", $file)) $extension = "DOCX"; // Word
+            if (preg_match("/\.ppt$|\.pptx$/i", $file)) $extension = "PPTX"; //Powerpoint
+            if (preg_match("/\.xls$|\.xlsx$/i", $file)) $extension = "XLXS"; // Excel
+            if (preg_match("/\.ogv$|\.mp4$|\.mpg$|\.mpeg$|\.mov$|\.avi$|\.wmv$|\.flv$|\.webm$/i", $file)) $extension = "VIDEO"; // video files
+            if (preg_match("/\.aiff$|\.aif$|\.wma$|\.aac$|\.flac$|\.mp3$|\.ogg$|\.m4a$/i", $file)) $extension = "AUDIO"; // audio files
 
             if ($extension != "") {
                 $files[] = array(

--- a/rss.php
+++ b/rss.php
@@ -152,6 +152,7 @@ if (is_writeable(".")) {
 /*===================*/
 /* XML Gen           */
 /*===================*/
+header('Content-Type: text/xml');
 $temp = explode("\n", $content);
 echo "<?xml version='1.0' encoding='UTF-8 '?>\n";
 echo "<rss version='2.0'>\n<channel>";

--- a/rss.php
+++ b/rss.php
@@ -165,6 +165,7 @@ for ($i=0; $i < $nb_items_rss && $i < count($temp); $i++) {
     echo "<item>\n";
     echo " <title>" . basename($temp[$i]) . "</title>\n";
     echo " <link>". $temp[$i] . "</link>\n";
+    echo " <guid>". $temp[$i] . "</guid>\n";
     echo " <description><![CDATA[ <img src='" . $temp[$i] . "'> ]]></description>\n";
     echo "</item>\n";
 }

--- a/rss.php
+++ b/rss.php
@@ -153,6 +153,7 @@ if (is_writeable(".")) {
 /* XML Gen           */
 /*===================*/
 $temp = explode("\n", $content);
+echo "<?xml version='1.0' encoding='UTF-8 '?>\n";
 echo "<rss version='2.0'>\n<channel>";
 echo "<title>$title</title>";
 echo "<link>$gallery_link</link>";


### PR DESCRIPTION
The current version incorrectly detect as RAR a file named **hangar10.jpg**.