### PR TITLE
Allow to use « .. » in directory name.

### DIFF
--- a/index.php
+++ b/index.php
@@ -146,15 +146,14 @@ if (!empty($_GET['dir'])) {
 	$requestedDir = $_GET['dir'];
 }
 
+$photoRoot = GALLERY_ROOT . 'photos/';
 $thumbdir = rtrim('photos/' . $requestedDir, '/');
-
-//$thumbdir = str_replace('/..', '', $thumbdir); // Prevent directory traversal attacks.
-if (strstr($thumbdir, '..') !== false) {
-	$requestedDir = '';
-	$thumbdir = rtrim('photos/', '/');
-}
-
 $currentdir = GALLERY_ROOT . $thumbdir;
+
+$thumbdirIsInPhotoRoot = strpos(realpath($thumbdir), realpath($photoRoot));
+if ($thumbdirIsInPhotoRoot === false) {
+	die("ERROR: Could not open " . htmlspecialchars(stripslashes($currentdir)) . " for reading!");
+}
 
 //-----------------------
 // READ FILES AND FOLDERS


### PR DESCRIPTION
Some people names their directories like this :
(2014-09-01..08)+Super+Party which is a perfectly valid directory name.

But the directory traversal protection was a bit protective and
prevented this.

Now it checks if the requested directory is in the gallery directory by
comparing their real path.

Fixes sebsauvage/MinigalNano/#89