### PR TITLE
Fix broken links to files of other filetypes than image

### DIFF
--- a/index.php
+++ b/index.php
@@ -353,11 +353,12 @@ if (is_dir($current_dir) && $handle = opendir($current_dir)) {
 			// audio files
 
 			if ($extension != "") {
+				$linkUrl = str_replace('%2F', '/', rawurlencode("$current_dir/$file"));
 				$files[] = array(
 					"name" => $file,
 					"date" => filemtime($current_dir . "/" . $file),
 					"size" => filesize($current_dir . "/" . $file),
-					"html" => "<li><a href='$current_dir/$file' title='$file'><em-pdf>" . padstring($file, 20) . "</em-pdf><span></span><img src='" . GALLERY_ROOT . "images/filetype_" . $extension . ".png' width='$thumb_size' height='$thumb_size' alt='$file' /></a>$filename_caption</li>");
+					"html" => "<li><a href='$linkUrl' title='$file'><em-pdf>" . padstring($file, 20) . "</em-pdf><span></span><img src='" . GALLERY_ROOT . "images/filetype_" . $extension . ".png' width='$thumb_size' height='$thumb_size' alt='$file' /></a>$filename_caption</li>");
 			}
 		}
 	}


### PR DESCRIPTION
The links to files that are not images are not URL-encoded which results in broken links when invalid characters are used in the file names. This pull request fixes this by encoding non-image URLs in the same way as image URLs are encoded.