### PR TITLE
Fixed a small bug

### DIFF
--- a/index.php
+++ b/index.php
@@ -123,7 +123,7 @@ function readEXIF($file) {
 		return "::" . implode(" | ", $exif_arr);
 	}
 
-	return $exif_arr;
+	return '';
 }
 
 function checkpermissions($file) {


### PR DESCRIPTION
Fixes a bug when "EXIF" data should be displayed but the image itself does not contain EXIF data.

In that situation, the word "Array" is displayed for the image EXIF data.